### PR TITLE
CI: Do not cancel all jobs in a workflow if one fails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   gcc:
     strategy:
+      fail-fast: false
       matrix:
         version: [9, 10, 11]
 
@@ -44,6 +45,7 @@ jobs:
 
   clang:
     strategy:
+      fail-fast: false
       matrix:
         version: [11, 12]
 
@@ -74,6 +76,7 @@ jobs:
 
   msvc:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
 


### PR DESCRIPTION
GitHub will usually cancel all running jobs in a matrix as soon as the first job in that matrix fails. However, this may be counter-productive, because even jobs that may pass will get cancelled this way, making it harder to figure out which jobs actually fail and which jobs would pass. For more information on the `fail-fast` configuration option see
<https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast>.

This change lets all jobs in the workflow run until they fail or pass, preventing premature cancellation. Seeing that there are currently problems with the GitHub Actions CI, this may help and make investigation of the causes easier.